### PR TITLE
In test.py, change assertEquals to assertEqual.

### DIFF
--- a/test.py
+++ b/test.py
@@ -793,7 +793,7 @@ class TestABAPlus(unittest.TestCase):
 
         abap = ABA_Plus(assumptions=assumptions, rules=rules, preferences=set())
 
-        self.assertEquals(abap.generate_all_deductions({a,b,e}), {a,b,c,e,f,g})
+        self.assertEqual(abap.generate_all_deductions({a,b,e}), {a,b,c,e,f,g})
 
 
 class TestABAPParser(unittest.TestCase):


### PR DESCRIPTION
When I run the unit tests, it gives a warning about this one use of the deprecated assertEquals. So, change it to assertEqual to avoid the warning.