### PR TITLE
Disable some WCP tests which are too strict.

### DIFF
--- a/test.py
+++ b/test.py
@@ -137,7 +137,7 @@ class TestABAPlus(unittest.TestCase):
 
         self.assertFalse(abap.deduction_exists(to_deduce=g, deduce_from=set([a, e])))
 
-    def test_simple_WCP_no_violation_check1(self):
+    def disabled_test_simple_WCP_no_violation_check1(self):
         a = Sentence("a")
         b = Sentence("b")
         c = Sentence("c")
@@ -150,7 +150,7 @@ class TestABAPlus(unittest.TestCase):
 
         self.assertTrue(abap.check_WCP())
 
-    def test_simple_WCP_no_violation_check2(self):
+    def disabled_test_simple_WCP_no_violation_check2(self):
         a = Sentence("a")
         b = Sentence("b")
         assumptions = set([a, b])
@@ -163,7 +163,7 @@ class TestABAPlus(unittest.TestCase):
 
         self.assertTrue(abap.check_WCP())
 
-    def test_simple_WCP_no_violation_check3(self):
+    def disabled_test_simple_WCP_no_violation_check3(self):
         a = Sentence("a")
         b = Sentence("b")
         c = Sentence("c")
@@ -261,7 +261,7 @@ class TestABAPlus(unittest.TestCase):
 
         self.assertFalse(abap.check_WCP())
 
-    def test_cycle_WCP_no_violation_check(self):
+    def disabled_test_cycle_WCP_no_violation_check(self):
         a = Sentence("a")
         b = Sentence("b")
         c = Sentence("c")
@@ -278,7 +278,7 @@ class TestABAPlus(unittest.TestCase):
 
         self.assertTrue(abap.check_WCP())
 
-    def test_complex_WCP_no_violation_check1(self):
+    def disabled_test_complex_WCP_no_violation_check1(self):
         alpha = Sentence("alpha")
         beta = Sentence("beta")
         gamma = Sentence("gamma")
@@ -319,7 +319,7 @@ class TestABAPlus(unittest.TestCase):
 
         self.assertTrue(abap.check_WCP())
 
-    def test_complex_WCP_no_violation_check2(self):
+    def disabled_test_complex_WCP_no_violation_check2(self):
         alpha = Sentence("alpha")
         beta = Sentence("beta")
         gamma = Sentence("gamma")


### PR DESCRIPTION
As suggested in issue #16 , temporarily skip some WCP tests which are too strict, after the WCP check was made more lax). A test is disabled by prepending `disabled_` to the method name.