### PR TITLE
In check_WCP, change tabs to spaces for consistent indentation.

### DIFF
--- a/aba_plus_.py
+++ b/aba_plus_.py
@@ -255,9 +255,9 @@ class ABA_Plus:
 			# if there is a deduction required for WCP
                         break
 			# then break the loop
-		    else:
+                    else:
 			# else, if for no <-minimal cuplrit a deduction required for WCP was found,
-			return False	
+                        return False
 			# then WCP is not satisfied
 
         return True 


### PR DESCRIPTION
@kcyras: Can you change the options on your editor to change tabs to spaces? As you know, Python depends on indentation, and it treats a tab differently from spaces. So, Python code has mixes tabs and spaces it can cause problems (as with your last commit).

@zb95: This pull request only fixes two lines of code which were causing errors. If you merge it, I will do another pull request to fix the indentation on the comment lines.